### PR TITLE
Ranking warning 

### DIFF
--- a/src/frontends/termination.py
+++ b/src/frontends/termination.py
@@ -31,7 +31,6 @@ def prove_terminates(filename):
              "--seed=1337 -a%d --varnames %s " +
              "--synth-strategy=genetic " +
              "-c1 " +
-             "--fastverif=True " +
              "-newsize=5 " +
              "-replaceprob=0.15 " +
              "-mutprob=0.1 " +

--- a/tests/termination/ranking.c
+++ b/tests/termination/ranking.c
@@ -2,7 +2,7 @@
 
 extern int prefix(word_t in_vars[NARGS], word_t out_vars[NARGS]);
 extern int guard(word_t in_vars[NARGS]);
-extern void body(word_t in_vars[NARGS], word_t out_vars[NARGS]);
+extern int body(word_t in_vars[NARGS], word_t out_vars[NARGS]);
 extern int assertion(word_t args[NARGS]);
 
 #define COND


### PR DESCRIPTION
Eliminated the warning when running kalashnikov for termination + removed the fastVerif argument in the frontend script for termination 
